### PR TITLE
portable version build with AI + Headset Control + Hungarian language support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,19 @@ default-run = "headset-battery-indicator-debug"
 name = "headset-battery-indicator-debug"
 path = "src/bin/debug.rs"
 
+[[bin]]
+name = "headset-battery-indicator"
+path = "src/main.rs"
+
+[[bin]]
+name = "headset-battery-indicator-portable"
+path = "src/main.rs"
+required-features = ["portable"]
+
+[features]
+default = []
+portable = []
+
 [dependencies]
 anyhow = "1.0.99"
 dirs = "6.0.0"

--- a/src/headset_control.rs
+++ b/src/headset_control.rs
@@ -1,7 +1,8 @@
 use crate::lang;
 use crate::lang::Key::*;
 
-use libc::{c_char, c_int, c_void};
+use anyhow::Context;
+use libc::{c_char, c_int, c_uchar, c_void};
 use std::ffi::CStr;
 
 #[repr(C)]
@@ -25,7 +26,55 @@ pub enum BatteryStatus {
     Timeout,
 }
 
-const BATTERY_CAPABILITY: c_int = 1;
+#[repr(i32)]
+#[derive(Debug, Clone, Copy)]
+enum Capability {
+    Sidetone = 0,
+    BatteryStatus = 1,
+    InactiveTime = 4,
+    MicrophoneMuteLedBrightness = 11,
+}
+
+impl Capability {
+    fn bit(self) -> c_int {
+        1 << self as c_int
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControlCapabilities {
+    pub sidetone: bool,
+    pub microphone_light: bool,
+    pub inactive_time: bool,
+}
+
+impl ControlCapabilities {
+    fn from_mask(mask: c_int) -> Self {
+        Self {
+            sidetone: mask & Capability::Sidetone.bit() != 0,
+            microphone_light: mask & Capability::MicrophoneMuteLedBrightness.bit() != 0,
+            inactive_time: mask & Capability::InactiveTime.bit() != 0,
+        }
+    }
+
+    pub fn has_controls(self) -> bool {
+        self.sidetone || self.microphone_light || self.inactive_time
+    }
+}
+
+#[repr(C)]
+struct HscSidetone {
+    current_level: c_uchar,
+    min_level: c_uchar,
+    max_level: c_uchar,
+}
+
+#[repr(C)]
+struct HscInactiveTime {
+    minutes: c_uchar,
+    min_minutes: c_uchar,
+    max_minutes: c_uchar,
+}
 
 #[link(name = "headsetcontrol_static")]
 unsafe extern "C" {
@@ -34,49 +83,149 @@ unsafe extern "C" {
     // unsafe fn hsc_get_name(headset: *mut c_void) -> *const c_char;
     unsafe fn hsc_get_product_name(headset: *mut c_void) -> *const c_char;
     unsafe fn hsc_supports(headset: *mut c_void, cap: c_int) -> bool;
+    unsafe fn hsc_get_capabilities(headset: *mut c_void) -> c_int;
     unsafe fn hsc_get_battery(headset: *mut c_void, battery: *mut HscBattery) -> c_int;
+    unsafe fn hsc_set_sidetone(
+        headset: *mut c_void,
+        level: c_uchar,
+        result: *mut HscSidetone,
+    ) -> c_int;
+    unsafe fn hsc_set_mic_mute_led_brightness(headset: *mut c_void, brightness: c_uchar) -> c_int;
+    unsafe fn hsc_set_inactive_time(
+        headset: *mut c_void,
+        minutes: c_uchar,
+        result: *mut HscInactiveTime,
+    ) -> c_int;
 }
 
 pub fn query_device() -> Option<Device> {
+    with_first_headset(|headset| unsafe {
+        let product_name = string_from_ptr(hsc_get_product_name(headset));
+        let capabilities = ControlCapabilities::from_mask(hsc_get_capabilities(headset));
+        let mut battery = unavailable_battery();
+
+        if hsc_supports(headset, Capability::BatteryStatus as c_int) {
+            let mut queried_battery = unavailable_battery();
+            if hsc_get_battery(headset, &mut queried_battery) == 0 {
+                battery = queried_battery;
+            }
+        }
+
+        Device {
+            product_name,
+            battery,
+            capabilities,
+        }
+    })
+}
+
+pub fn set_sidetone_enabled(enabled: bool) -> anyhow::Result<()> {
+    set_control(
+        Capability::Sidetone,
+        |headset| unsafe {
+            let mut result = HscSidetone {
+                current_level: 0,
+                min_level: 0,
+                max_level: 0,
+            };
+            hsc_set_sidetone(headset, if enabled { 128 } else { 0 }, &mut result)
+        },
+        "setting sidetone",
+    )
+}
+
+pub fn set_microphone_light_enabled(enabled: bool) -> anyhow::Result<()> {
+    set_control(
+        Capability::MicrophoneMuteLedBrightness,
+        |headset| unsafe { hsc_set_mic_mute_led_brightness(headset, if enabled { 3 } else { 0 }) },
+        "setting microphone light",
+    )
+}
+
+pub fn set_inactive_time_minutes(minutes: u8) -> anyhow::Result<()> {
+    set_control(
+        Capability::InactiveTime,
+        |headset| unsafe {
+            let mut result = HscInactiveTime {
+                minutes: 0,
+                min_minutes: 0,
+                max_minutes: 0,
+            };
+            hsc_set_inactive_time(headset, minutes, &mut result)
+        },
+        "setting inactive time",
+    )
+}
+
+fn set_control(
+    capability: Capability,
+    setter: impl FnOnce(*mut c_void) -> c_int,
+    action: &'static str,
+) -> anyhow::Result<()> {
+    let result = with_first_headset(|headset| unsafe {
+        if !hsc_supports(headset, capability as c_int) {
+            return Err(anyhow::anyhow!("capability is not supported"));
+        }
+
+        let code = setter(headset);
+        if code != 0 {
+            return Err(anyhow::anyhow!("HeadsetControl returned {code}"));
+        }
+
+        Ok(())
+    });
+
+    result
+        .context("discovering headset")?
+        .with_context(|| action)
+}
+
+fn with_first_headset<T>(f: impl FnOnce(*mut c_void) -> T) -> Option<T> {
     unsafe {
         let mut headsets: *mut c_void = std::ptr::null_mut();
         let count = hsc_discover(&mut headsets);
 
-        if count > 0 {
+        if count <= 0 || headsets.is_null() {
+            return None;
+        }
+
+        let result = {
             let headset_array =
                 std::slice::from_raw_parts(headsets as *const *mut c_void, count as usize);
+            f(headset_array[0])
+        };
 
-            let headset = headset_array[0]; // Just take the first headset found
-            if hsc_supports(headset, BATTERY_CAPABILITY) {
-                let mut battery = HscBattery {
-                    level_percent: 0,
-                    status: BatteryStatus::Unavailable,
-                    voltage_mv: -1,
-                    time_to_full_min: -1,
-                    time_to_empty_min: -1,
-                };
-                if hsc_get_battery(headset, &mut battery) == 0 {
-                    let product_name = CStr::from_ptr(hsc_get_product_name(headset))
-                        .to_str()
-                        .unwrap_or("Unknown")
-                        .to_string();
+        hsc_free_headsets(headsets, count);
 
-                    hsc_free_headsets(headsets, count);
-                    return Some(Device {
-                        product_name,
-                        battery,
-                    });
-                }
-            }
-        }
+        Some(result)
+    }
+}
+
+fn unavailable_battery() -> HscBattery {
+    HscBattery {
+        level_percent: 0,
+        status: BatteryStatus::Unavailable,
+        voltage_mv: -1,
+        time_to_full_min: -1,
+        time_to_empty_min: -1,
+    }
+}
+
+unsafe fn string_from_ptr(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        return "Unknown".to_string();
     }
 
-    None
+    unsafe { CStr::from_ptr(ptr) }
+        .to_str()
+        .unwrap_or("Unknown")
+        .to_string()
 }
 
 pub struct Device {
     pub product_name: String,
     pub battery: HscBattery,
+    pub capabilities: ControlCapabilities,
 }
 
 impl Device {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -48,8 +48,7 @@ pub fn generate_number_icon(
         }
     }
 
-    tray_icon::Icon::from_rgba(img, size, size)
-        .context("creating icon from generated image buffer")
+    tray_icon::Icon::from_rgba(img, size, size).context("creating icon from generated image buffer")
 }
 
 pub fn load_from_resource(

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -79,6 +79,19 @@ pub fn t(key: Key) -> &'static str {
             version => "版本",
             update_available => "有更新可用",
         },
+        Lang::Hu => match key {
+            no_headset_found => "Nem található fejhallgató vagy adapter",
+            view_logs => "Logok megtekintése",
+            quit_program => "Bezárás",
+            device_charging => "(Töltés alatt)",
+            device_disconnected => "(Lecsatlakoztatva)",
+            battery_unavailable => "(Akkumulátor információ nem elérhető)",
+            show_notifications => "Értesítések megjelenítése",
+            show_text_icon => "Akkumulátor százalékos megjelenitése iconban",
+            notifications_enabled_message => "Értesítések engedélyezve",
+            version => "Verzió",
+            update_available => "Frissítés elérhető",
+        },
     }
 }
 
@@ -90,6 +103,7 @@ pub enum Lang {
     It,
     Pt,
     Zh,
+    Hu,
 }
 
 #[allow(non_camel_case_types)]
@@ -120,6 +134,7 @@ pub static LANG: LazyLock<Lang> = LazyLock::new(|| {
         "it" | "it-IT" | "it-CH" => Lang::It,
         "pt" | "pt-PT" | "pt-BR" => Lang::Pt,
         "zh" | "zh-CN" => Lang::Zh,
+        "hu" | "hu-HU" => Lang::Hu,
         _ => Lang::En,
     }
 });

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -13,6 +13,10 @@ pub fn t(key: Key) -> &'static str {
             notifications_enabled_message => "Notifications enabled",
             version => "Version",
             update_available => "Update available",
+            control_headset => "Control headset",
+            sidetone => "Sidetone",
+            microphone_light => "Microphone LED when muted",
+            inactive_time => "Inactive time",
         },
         Lang::Fi => match key {
             no_headset_found => "Kuulokkeita ei löytynyt",
@@ -26,6 +30,7 @@ pub fn t(key: Key) -> &'static str {
             show_text_icon => "Näytä akun tila numerona",
             version => "Versio",
             update_available => "Päivitys saatavilla",
+            _ => english(key),
         },
         Lang::De => match key {
             no_headset_found => "Kein Headset gefunden",
@@ -39,6 +44,7 @@ pub fn t(key: Key) -> &'static str {
             show_text_icon => "Batteriestatus als Zahlensymbol anzeigen",
             version => "Version",
             update_available => "Update verfügbar",
+            _ => english(key),
         },
         Lang::It => match key {
             no_headset_found => "Nessuna cuffia trovata",
@@ -52,6 +58,7 @@ pub fn t(key: Key) -> &'static str {
             show_text_icon => "Mostra stato batteria come icona numerica",
             version => "Versione",
             update_available => "Aggiornamento disponibile",
+            _ => english(key),
         },
         Lang::Pt => match key {
             no_headset_found => "Nenhum headset encontrado",
@@ -65,6 +72,7 @@ pub fn t(key: Key) -> &'static str {
             show_text_icon => "Mostrar estado da bateria como ícone numérico",
             version => "Versão",
             update_available => "Atualização disponível",
+            _ => english(key),
         },
         Lang::Zh => match key {
             no_headset_found => "未找到耳机",
@@ -78,6 +86,7 @@ pub fn t(key: Key) -> &'static str {
             notifications_enabled_message => "通知已启用",
             version => "版本",
             update_available => "有更新可用",
+            _ => english(key),
         },
         Lang::Hu => match key {
             no_headset_found => "Nem található fejhallgató vagy adapter",
@@ -87,11 +96,33 @@ pub fn t(key: Key) -> &'static str {
             device_disconnected => "(Lecsatlakoztatva)",
             battery_unavailable => "(Akkumulátor információ nem elérhető)",
             show_notifications => "Értesítések megjelenítése",
-            show_text_icon => "Akkumulátor százalékos megjelenitése iconban",
+            show_text_icon => "Akkumulátor százalékos megjelenítése ikonban",
             notifications_enabled_message => "Értesítések engedélyezve",
             version => "Verzió",
             update_available => "Frissítés elérhető",
+            _ => english(key),
         },
+    }
+}
+
+fn english(key: Key) -> &'static str {
+    use Key::*;
+    match key {
+        no_headset_found => "No headset found",
+        view_logs => "View logs",
+        quit_program => "Close",
+        device_charging => "(Charging)",
+        device_disconnected => "(Disconnected)",
+        battery_unavailable => "(Battery unavailable)",
+        show_notifications => "Show notifications",
+        show_text_icon => "Show battery percentage as number icon",
+        notifications_enabled_message => "Notifications enabled",
+        version => "Version",
+        update_available => "Update available",
+        control_headset => "Control headset",
+        sidetone => "Sidetone",
+        microphone_light => "Microphone LED when muted",
+        inactive_time => "Inactive time",
     }
 }
 
@@ -107,6 +138,7 @@ pub enum Lang {
 }
 
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub enum Key {
     no_headset_found,
     view_logs,
@@ -119,6 +151,10 @@ pub enum Key {
     notifications_enabled_message,
     version,
     update_available,
+    control_headset,
+    sidetone,
+    microphone_light,
+    inactive_time,
 }
 
 use std::sync::LazyLock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@ mod version_check;
 use anyhow::Result;
 use lang::Key::*;
 use std::{
-    sync::LazyLock, time::{Duration, Instant}
+    sync::LazyLock,
+    time::{Duration, Instant},
 };
 use windows::{
     Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA},
@@ -63,7 +64,7 @@ impl AppState {
     pub fn init() -> anyhow::Result<Self> {
         #[cfg(not(feature = "portable"))]
         let settings = settings::Settings::load().context("loading config from registry")?;
-        
+
         #[cfg(feature = "portable")]
         let settings = settings::Settings::load().context("loading config from ini")?;
 
@@ -106,6 +107,10 @@ impl AppState {
 
         match result {
             None => {
+                if let Err(e) = self.context_menu.clear_control_menu() {
+                    error!("Failed to clear headset control menu: {e:?}");
+                }
+
                 if let Some(notifier) = &mut self.notifier {
                     notifier.update(0, BatteryStatus::Unavailable, "");
                 }
@@ -120,6 +125,13 @@ impl AppState {
                 Ok(())
             }
             Some(device) => {
+                if let Err(e) = self
+                    .context_menu
+                    .sync_control_menu(device.capabilities, self.settings)
+                {
+                    error!("Failed to update headset control menu: {e:?}");
+                }
+
                 let battery_level = device.battery.level_percent as isize;
                 let battery_status = device.battery.status;
                 let product_name = device.product_name.to_string();
@@ -168,6 +180,64 @@ impl AppState {
                 .context("loading icon from resource")
         }
     }
+
+    fn handle_control_action(&mut self, action: menu::ControlAction) {
+        match action {
+            menu::ControlAction::Sidetone => {
+                let previous = self.settings.sidetone_enabled;
+                let next = !previous;
+
+                match headset_control::set_sidetone_enabled(next) {
+                    Ok(()) => {
+                        self.settings.sidetone_enabled = next;
+                        self.context_menu.set_sidetone_checked(next);
+                        if let Err(e) = self.settings.save() {
+                            error!("Failed to save settings: {e:?}");
+                        }
+                    }
+                    Err(e) => {
+                        self.context_menu.set_sidetone_checked(previous);
+                        error!("Failed to set sidetone: {e:?}");
+                    }
+                }
+            }
+            menu::ControlAction::MicrophoneLight => {
+                let previous = self.settings.microphone_light_enabled;
+                let next = !previous;
+
+                match headset_control::set_microphone_light_enabled(next) {
+                    Ok(()) => {
+                        self.settings.microphone_light_enabled = next;
+                        self.context_menu.set_microphone_light_checked(next);
+                        if let Err(e) = self.settings.save() {
+                            error!("Failed to save settings: {e:?}");
+                        }
+                    }
+                    Err(e) => {
+                        self.context_menu.set_microphone_light_checked(previous);
+                        error!("Failed to set microphone light: {e:?}");
+                    }
+                }
+            }
+            menu::ControlAction::InactiveTime(minutes) => {
+                let previous = self.settings.inactive_time_minutes;
+
+                match headset_control::set_inactive_time_minutes(minutes) {
+                    Ok(()) => {
+                        self.settings.inactive_time_minutes = minutes;
+                        self.context_menu.set_inactive_time_checked(minutes);
+                        if let Err(e) = self.settings.save() {
+                            error!("Failed to save settings: {e:?}");
+                        }
+                    }
+                    Err(e) => {
+                        self.context_menu.set_inactive_time_checked(previous);
+                        error!("Failed to set inactive time: {e:?}");
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl ApplicationHandler<()> for AppState {
@@ -209,6 +279,11 @@ impl ApplicationHandler<()> for AppState {
             self.last_update = Instant::now();
         }
         if let Ok(event) = MenuEvent::receiver().try_recv() {
+            if let Some(action) = self.context_menu.control_action_for_event(&event) {
+                self.handle_control_action(action);
+                return;
+            }
+
             match event.id {
                 id if id == self.context_menu.menu_enable_notifications.id() => {
                     self.settings.notifications_enabled = !self.settings.notifications_enabled;
@@ -242,17 +317,6 @@ impl ApplicationHandler<()> for AppState {
 
                     if let Err(e) = self.settings.save() {
                         error!("Failed to save settings: {e:?}");
-                    }
-                }
-
-                id if id == self.context_menu.menu_trigger_notification.id() => {
-                    #[cfg(debug_assertions)]
-                    {
-                        if let Some(notifier) = &mut self.notifier {
-                            notifier
-                                .show_notification("Test Device", "Battery low (50%)")
-                                .expect("Sending test notification");
-                        }
                     }
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,11 @@ pub fn run() -> anyhow::Result<()> {
 
 impl AppState {
     pub fn init() -> anyhow::Result<Self> {
+        #[cfg(not(feature = "portable"))]
         let settings = settings::Settings::load().context("loading config from registry")?;
+        
+        #[cfg(feature = "portable")]
+        let settings = settings::Settings::load().context("loading config from ini")?;
 
         let icon = Self::load_icon(settings, Theme::Dark, 0, BatteryStatus::Unavailable)
             .context("loading fallback icon")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,12 @@ pub fn init_file_logger() -> anyhow::Result<()> {
             anyhow::bail!("Failed to get current directory: {err}");
         }
         Ok(current_exe) => {
-            let log_file = File::options()
-                .append(true)
-                .create(true)
-                .open(current_exe.parent().unwrap().join("headset-battery-indicator.log"))?;
+            let log_file = File::options().append(true).create(true).open(
+                current_exe
+                    .parent()
+                    .unwrap()
+                    .join("headset-battery-indicator.log"),
+            )?;
 
             WriteLogger::init(
                 log::LevelFilter::Info,

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -4,12 +4,27 @@ use std::fmt::Debug;
 use anyhow::Context;
 use log::error;
 use tray_icon::menu::MenuEvent;
-use tray_icon::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use winit::event_loop;
 
+use crate::headset_control::ControlCapabilities;
 use crate::lang;
 use crate::lang::Key::*;
 use crate::settings::Settings;
+
+pub enum ControlAction {
+    Sidetone,
+    MicrophoneLight,
+    InactiveTime(u8),
+}
+
+const INACTIVE_TIME_OPTIONS: &[(u8, &str)] = &[
+    (0, "Off"),
+    (5, "5 min"),
+    (15, "15 min"),
+    (30, "30 min"),
+    (60, "60 min"),
+];
 
 pub struct ContextMenu {
     pub menu: Menu,
@@ -17,8 +32,17 @@ pub struct ContextMenu {
     pub menu_show_text_icon: CheckMenuItem,
     menu_logs: MenuItem,
     menu_close: MenuItem,
-    pub menu_trigger_notification: MenuItem,
     menu_update_available: Option<MenuItem>,
+    control_menu: Option<ControlMenu>,
+    control_capabilities: Option<ControlCapabilities>,
+}
+
+struct ControlMenu {
+    submenu: Submenu,
+    sidetone: CheckMenuItem,
+    microphone_light: CheckMenuItem,
+    _inactive_time: Submenu,
+    inactive_time_items: Vec<(u8, CheckMenuItem)>,
 }
 
 impl ContextMenu {
@@ -47,10 +71,6 @@ impl ContextMenu {
 
         let menu_logs = MenuItem::new(lang::t(view_logs), true, None);
         let menu_close = MenuItem::new(lang::t(quit_program), true, None);
-        let menu_trigger_notification = MenuItem::new("Trigger Test Notification", true, None);
-
-        #[cfg(debug_assertions)]
-        menu.append(&menu_trigger_notification)?;
 
         menu.append_items(&[&menu_notifications, &menu_show_text_icon, &menu_logs])?;
         menu.append(&PredefinedMenuItem::separator())?;
@@ -62,8 +82,9 @@ impl ContextMenu {
             menu_show_text_icon,
             menu_logs,
             menu_close,
-            menu_trigger_notification,
             menu_update_available: None,
+            control_menu: None,
+            control_capabilities: None,
         })
     }
 
@@ -81,6 +102,143 @@ impl ContextMenu {
         self.menu_update_available = Some(menu_item);
 
         Ok(())
+    }
+
+    pub fn sync_control_menu(
+        &mut self,
+        capabilities: ControlCapabilities,
+        settings: Settings,
+    ) -> anyhow::Result<()> {
+        if capabilities.has_controls() {
+            if self.control_capabilities != Some(capabilities) {
+                self.rebuild_control_menu(capabilities, settings)?;
+            }
+            self.update_control_checks(settings);
+        } else {
+            self.remove_control_menu()?;
+            self.control_capabilities = None;
+        }
+
+        Ok(())
+    }
+
+    pub fn clear_control_menu(&mut self) -> anyhow::Result<()> {
+        self.remove_control_menu()?;
+        self.control_capabilities = None;
+        Ok(())
+    }
+
+    pub fn control_action_for_event(&self, event: &MenuEvent) -> Option<ControlAction> {
+        let control_menu = self.control_menu.as_ref()?;
+
+        if *control_menu.sidetone.id() == event.id {
+            return Some(ControlAction::Sidetone);
+        }
+
+        if *control_menu.microphone_light.id() == event.id {
+            return Some(ControlAction::MicrophoneLight);
+        }
+
+        for (minutes, item) in &control_menu.inactive_time_items {
+            if *item.id() == event.id {
+                return Some(ControlAction::InactiveTime(*minutes));
+            }
+        }
+
+        None
+    }
+
+    pub fn set_sidetone_checked(&self, checked: bool) {
+        if let Some(control_menu) = self.control_menu.as_ref() {
+            control_menu.sidetone.set_checked(checked);
+        }
+    }
+
+    pub fn set_microphone_light_checked(&self, checked: bool) {
+        if let Some(control_menu) = self.control_menu.as_ref() {
+            control_menu.microphone_light.set_checked(checked);
+        }
+    }
+
+    pub fn set_inactive_time_checked(&self, selected_minutes: u8) {
+        if let Some(control_menu) = self.control_menu.as_ref() {
+            for (minutes, item) in &control_menu.inactive_time_items {
+                item.set_checked(*minutes == selected_minutes);
+            }
+        }
+    }
+
+    fn rebuild_control_menu(
+        &mut self,
+        capabilities: ControlCapabilities,
+        settings: Settings,
+    ) -> anyhow::Result<()> {
+        self.remove_control_menu()?;
+
+        let submenu = Submenu::new(lang::t(control_headset), true);
+
+        let sidetone_item = CheckMenuItem::new(
+            lang::t(sidetone),
+            capabilities.sidetone,
+            settings.sidetone_enabled,
+            None,
+        );
+        submenu.append(&sidetone_item)?;
+
+        let microphone_light_item = CheckMenuItem::new(
+            lang::t(microphone_light),
+            capabilities.microphone_light,
+            settings.microphone_light_enabled,
+            None,
+        );
+        submenu.append(&microphone_light_item)?;
+
+        let inactive_time_menu = Submenu::new(lang::t(inactive_time), capabilities.inactive_time);
+        let mut inactive_time_items = Vec::new();
+        for (minutes, label) in INACTIVE_TIME_OPTIONS {
+            let item = CheckMenuItem::new(
+                *label,
+                capabilities.inactive_time,
+                *minutes == settings.inactive_time_minutes,
+                None,
+            );
+            inactive_time_menu.append(&item)?;
+            inactive_time_items.push((*minutes, item));
+        }
+        submenu.append(&inactive_time_menu)?;
+
+        let position = self
+            .menu
+            .items()
+            .iter()
+            .position(|item| *item.id() == *self.menu_logs.id())
+            .unwrap_or_else(|| self.menu.items().len());
+
+        self.menu.insert(&submenu, position)?;
+        self.control_menu = Some(ControlMenu {
+            submenu,
+            sidetone: sidetone_item,
+            microphone_light: microphone_light_item,
+            _inactive_time: inactive_time_menu,
+            inactive_time_items,
+        });
+        self.control_capabilities = Some(capabilities);
+
+        Ok(())
+    }
+
+    fn remove_control_menu(&mut self) -> anyhow::Result<()> {
+        if let Some(control_menu) = self.control_menu.take() {
+            self.menu.remove(&control_menu.submenu)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_control_checks(&self, settings: Settings) {
+        self.set_sidetone_checked(settings.sidetone_enabled);
+        self.set_microphone_light_checked(settings.microphone_light_enabled);
+        self.set_inactive_time_checked(settings.inactive_time_minutes);
     }
 
     pub fn handle_event(&mut self, event: MenuEvent, event_loop: &event_loop::ActiveEventLoop) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,9 @@ use winreg::enums::HKEY_CURRENT_USER;
 pub struct Settings {
     pub notifications_enabled: bool,
     pub use_number_icon: bool,
+    pub sidetone_enabled: bool,
+    pub microphone_light_enabled: bool,
+    pub inactive_time_minutes: u8,
 }
 
 #[cfg(not(feature = "portable"))]
@@ -20,10 +23,17 @@ impl Settings {
 
         let notifications_enabled: u32 = key.get_value("NotificationsEnabled").unwrap_or_default();
         let use_number_icon: u32 = key.get_value("UseNumberIcon").unwrap_or_default();
+        let sidetone_enabled: u32 = key.get_value("SidetoneEnabled").unwrap_or_default();
+        let microphone_light_enabled: u32 =
+            key.get_value("MicrophoneLightEnabled").unwrap_or_default();
+        let inactive_time_minutes: u32 = key.get_value("InactiveTimeMinutes").unwrap_or_default();
 
         let settings = Self {
             notifications_enabled: notifications_enabled != 0,
             use_number_icon: use_number_icon != 0,
+            sidetone_enabled: sidetone_enabled != 0,
+            microphone_light_enabled: microphone_light_enabled != 0,
+            inactive_time_minutes: inactive_time_minutes.min(u8::MAX as u32) as u8,
         };
         log::debug!("Loaded settings: {:?}", settings);
         Ok(settings)
@@ -40,6 +50,18 @@ impl Settings {
 
         key.set_value("UseNumberIcon", &(self.use_number_icon as u32))
             .context("setting UseNumberIcon value")?;
+
+        key.set_value("SidetoneEnabled", &(self.sidetone_enabled as u32))
+            .context("setting SidetoneEnabled value")?;
+
+        key.set_value(
+            "MicrophoneLightEnabled",
+            &(self.microphone_light_enabled as u32),
+        )
+        .context("setting MicrophoneLightEnabled value")?;
+
+        key.set_value("InactiveTimeMinutes", &(self.inactive_time_minutes as u32))
+            .context("setting InactiveTimeMinutes value")?;
 
         Ok(())
     }
@@ -59,6 +81,9 @@ impl Settings {
         let mut settings = Self {
             notifications_enabled: false,
             use_number_icon: false,
+            sidetone_enabled: false,
+            microphone_light_enabled: false,
+            inactive_time_minutes: 0,
         };
 
         if path.exists() {
@@ -69,6 +94,13 @@ impl Settings {
                     settings.notifications_enabled = line.ends_with("true") || line.ends_with("1");
                 } else if line.starts_with("UseNumberIcon=") {
                     settings.use_number_icon = line.ends_with("true") || line.ends_with("1");
+                } else if line.starts_with("SidetoneEnabled=") {
+                    settings.sidetone_enabled = line.ends_with("true") || line.ends_with("1");
+                } else if line.starts_with("MicrophoneLightEnabled=") {
+                    settings.microphone_light_enabled =
+                        line.ends_with("true") || line.ends_with("1");
+                } else if let Some(value) = line.strip_prefix("InactiveTimeMinutes=") {
+                    settings.inactive_time_minutes = value.parse().unwrap_or(0);
                 }
             }
         } else {
@@ -84,8 +116,12 @@ impl Settings {
         let path = Self::get_settings_path()?;
 
         let contents = format!(
-            "NotificationsEnabled={}\nUseNumberIcon={}\n",
-            self.notifications_enabled, self.use_number_icon
+            "NotificationsEnabled={}\nUseNumberIcon={}\nSidetoneEnabled={}\nMicrophoneLightEnabled={}\nInactiveTimeMinutes={}\n",
+            self.notifications_enabled,
+            self.use_number_icon,
+            self.sidetone_enabled,
+            self.microphone_light_enabled,
+            self.inactive_time_minutes
         );
 
         fs::write(path, contents).context("writing settings.ini")?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,7 @@
 use anyhow::{Context, Result};
+#[cfg(feature = "portable")]
+use std::{fs, path::PathBuf};
+#[cfg(not(feature = "portable"))]
 use winreg::enums::HKEY_CURRENT_USER;
 
 #[derive(Debug, Clone, Copy)]
@@ -7,6 +10,7 @@ pub struct Settings {
     pub use_number_icon: bool,
 }
 
+#[cfg(not(feature = "portable"))]
 impl Settings {
     pub fn load() -> Result<Self> {
         let hkcu = winreg::RegKey::predef(HKEY_CURRENT_USER);
@@ -16,7 +20,6 @@ impl Settings {
 
         let notifications_enabled: u32 = key.get_value("NotificationsEnabled").unwrap_or_default();
         let use_number_icon: u32 = key.get_value("UseNumberIcon").unwrap_or_default();
-
 
         let settings = Self {
             notifications_enabled: notifications_enabled != 0,
@@ -37,6 +40,55 @@ impl Settings {
 
         key.set_value("UseNumberIcon", &(self.use_number_icon as u32))
             .context("setting UseNumberIcon value")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "portable")]
+impl Settings {
+    fn get_settings_path() -> Result<PathBuf> {
+        let mut path = std::env::current_exe().context("getting current executable path")?;
+        path.set_file_name("settings.ini");
+        Ok(path)
+    }
+
+    pub fn load() -> Result<Self> {
+        let path = Self::get_settings_path()?;
+
+        let mut settings = Self {
+            notifications_enabled: false,
+            use_number_icon: false,
+        };
+
+        if path.exists() {
+            let contents = fs::read_to_string(&path).context("reading settings.ini")?;
+            for line in contents.lines() {
+                let line = line.trim();
+                if line.starts_with("NotificationsEnabled=") {
+                    settings.notifications_enabled = line.ends_with("true") || line.ends_with("1");
+                } else if line.starts_with("UseNumberIcon=") {
+                    settings.use_number_icon = line.ends_with("true") || line.ends_with("1");
+                }
+            }
+        } else {
+            // Create default settings file if it doesn't exist
+            let _ = settings.save();
+        }
+
+        log::debug!("Loaded settings from ini: {:?}", settings);
+        Ok(settings)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = Self::get_settings_path()?;
+
+        let contents = format!(
+            "NotificationsEnabled={}\nUseNumberIcon={}\n",
+            self.notifications_enabled, self.use_number_icon
+        );
+
+        fs::write(path, contents).context("writing settings.ini")?;
 
         Ok(())
     }

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -43,7 +43,7 @@ fn check_for_updates(current_version: &str) -> Result<bool, Box<dyn std::error::
         .read_json()?;
 
     let latest_version = response.tag_name.trim_start_matches('v');
-    
+
     if is_newer_version(latest_version, current_version) {
         info!("New version available: {latest_version} (current: {current_version})");
         Ok(true)
@@ -55,11 +55,8 @@ fn check_for_updates(current_version: &str) -> Result<bool, Box<dyn std::error::
 /// Compares two semver-like version strings (e.g., "3.3.0" vs "3.2.1").
 /// Returns true if `latest` is newer than `current`.
 fn is_newer_version(latest: &str, current: &str) -> bool {
-    let parse_version = |v: &str| -> Vec<u32> {
-        v.split('.')
-            .filter_map(|s| s.parse::<u32>().ok())
-            .collect()
-    };
+    let parse_version =
+        |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse::<u32>().ok()).collect() };
 
     let latest_parts = parse_version(latest);
     let current_parts = parse_version(current);


### PR DESCRIPTION
Added portable version build with **AI** + Hungarian language support

cargo build --release --features portable --bin headset-battery-indicator-portable

___________________________




Added a dynamic `Control headset` submenu to the tray menu for HeadsetControl-powered device controls.

The implementation was written by GPT-5.5 High and reviewed through multiple self-check passes during development.

## Changes

- Added HeadsetControl FFI bindings for:
  - capability discovery
  - sidetone control
  - microphone muted LED brightness
  - inactive time / auto power-off

- Added a dynamic tray submenu:
  - `Control headset`
  - `Sidetone`
  - `Microphone LED when muted`
  - `Inactive time`
    - `Off`
    - `5 min`
    - `15 min`
    - `30 min`
    - `60 min`

- Added persisted settings for:
  - sidetone enabled state
  - microphone muted LED state
  - inactive time minutes

- Removed the debug-only `Trigger Test Notification` tray menu item completely.

- Kept microphone mute out of scope because HeadsetControl does not expose a dedicated mic mute/unmute command for this device; no mic volume workaround was added.

## Behavior

- `Control headset` appears only when the detected headset has at least one implemented control capability.
- Implemented controls are shown in the submenu.
- Controls unsupported by the current headset are disabled.
- Toggle/check state is based on the app’s last saved setting, not read back from the headset.

## Validation

- Ran `cargo fmt`
- Ran `cargo build --features portable`
- Ran `cargo test --features portable`

Both build and tests pass.